### PR TITLE
Rename forge--{ list => ls }-notifications-all

### DIFF
--- a/gh-notify.el
+++ b/gh-notify.el
@@ -967,7 +967,7 @@ Optionally provide a CALLBACK."
 (defun gh-notify--forge-get-notifications ()
   "Get forge notifications."
   (let ((results '()))
-    (when-let ((ns (forge--list-notifications-all)))
+    (when-let ((ns (forge--ls-notifications-all)))
       (pcase-dolist (`(,_ . ,ns) (--group-by (oref it repository) ns))
         (let ((repo (forge-get-repository (car ns))))
           (dolist (notify ns)


### PR DESCRIPTION
The function `forge--list-notifications-all` was recently renamed to `forge--ls-notifications-all` (https://github.com/magit/forge/commit/0394d232e04722a0421b024828de0301c9a1153e), causing `gh-notify--forge-get-notifications` to break. This patch fixes this.