### PR TITLE
Update functions to reflect recent forge changes

### DIFF
--- a/gh-notify.el
+++ b/gh-notify.el
@@ -967,7 +967,7 @@ Optionally provide a CALLBACK."
 (defun gh-notify--forge-get-notifications ()
   "Get forge notifications."
   (let ((results '()))
-    (when-let ((ns (forge--list-notifications-all)))
+    (when-let ((ns (forge--ls-notifications-all)))
       (pcase-dolist (`(,_ . ,ns) (--group-by (oref it repository) ns))
         (let ((repo (forge-get-repository (car ns))))
           (dolist (notify ns)

--- a/gh-notify.el
+++ b/gh-notify.el
@@ -1078,7 +1078,7 @@ All pull request on prefix P."
                           (string-to-number (match-string 1 choice)))))
           (with-demoted-errors "Warning: %S"
             (with-temp-buffer
-              (forge-visit (forge-get-pullreq repo topic)))))))))
+              (forge-visit-pullreq (forge-get-pullreq repo topic)))))))))
 
 (defun gh-notify-ls-issues-at-point (P)
   "Navigate a list of open issues available for notification at point.
@@ -1106,7 +1106,7 @@ All issues on prefix P."
                           (string-to-number (match-string 1 choice)))))
           (with-demoted-errors "Warning: %S"
             (with-temp-buffer
-              (forge-visit (forge-get-issue repo topic)))))))))
+              (forge-visit-issue (forge-get-issue repo topic)))))))))
 
 (defun gh-notify-display-state ()
   "Show the current state for an issue or pull request notification."
@@ -1380,7 +1380,10 @@ If there is a region, only unmark notifications in region."
       ;; XXX: improve me, needs to detect when we don't have a full repo locally
       ;; XXX: which we can probably just pull from the Forge DB
       (if repo
-          (forge-visit repo)
+	  (let ((worktree (oref repo worktree)))
+	    (if (and worktree (file-directory-p worktree))
+		(magit-status-setup-buffer worktree)
+	      (forge-list-issues (oref repo id))))
         (message "No forge github repo available at point!")))))
 
 (defun gh-notify-mark-notification-read (notification)
@@ -1446,14 +1449,14 @@ Browse issue or PR on prefix P."
              (gh-notify-mark-notification-read current-notification)
              (with-demoted-errors "Warning: %S"
                (with-temp-buffer
-                 (forge-visit (forge-get-issue repo topic))
+                 (forge-visit-issue (forge-get-issue repo topic))
                  (forge-pull-topic topic))))
             ('pullreq
              ;;(message "handling a pull request ...")
              (gh-notify-mark-notification-read current-notification)
              (with-demoted-errors "Warning: %S"
                (with-temp-buffer
-                 (forge-visit (forge-get-pullreq repo topic))
+                 (forge-visit-pullreq (forge-get-pullreq repo topic))
                  (forge-pull-topic topic))))
             ('commit
              (message "Commit not handled yet!"))


### PR DESCRIPTION
The function `forge--list-notifications-all` was recently renamed to `forge--ls-notifications-all` (https://github.com/magit/forge/commit/0394d232e04722a0421b024828de0301c9a1153e).

In addition, the function `forge-visit` was recently removed (https://github.com/magit/forge/commit/96c96147070f58063032fdc7919e4048bfc8aae1).

This patch fixes the breakage that occurred as a result of these changes. Please test it before merging; I am not familiar with some of the patched commands and am not entirely sure they are functioning correctly.

(Note that I submitted another pull request earlier (https://github.com/anticomputer/gh-notify/pull/13) that addressed only the change due to the renaming of `forge--list-notifications-all`, before I realized that `forge-visit` had been removed as part of a more extensive refactoring of the `forge` package. This pull request supersedes that earlier one, which has now been closed.)